### PR TITLE
add sdl-freerdp3 as a valid RDP client choice

### DIFF
--- a/src/renderer/utils/getFreeRDP.ts
+++ b/src/renderer/utils/getFreeRDP.ts
@@ -25,6 +25,7 @@ const freeRDPInstallations = [
     new FreeRDPInstallation("xfreerdp3"),
     new FreeRDPInstallation("xfreerdp"),
     new FreeRDPInstallation("flatpak", ["run", "--command=xfreerdp", "com.freerdp.FreeRDP"]),
+    new FreeRDPInstallation("sdl-freerdp3"),
 ];
 
 /**

--- a/src/renderer/utils/getFreeRDP.ts
+++ b/src/renderer/utils/getFreeRDP.ts
@@ -26,6 +26,9 @@ const freeRDPInstallations = [
     new FreeRDPInstallation("xfreerdp"),
     new FreeRDPInstallation("flatpak", ["run", "--command=xfreerdp", "com.freerdp.FreeRDP"]),
     new FreeRDPInstallation("sdl-freerdp3"),
+    new FreeRDPInstallation("sdl-freerdp"),
+    new FreeRDPInstallation("sdl3-freerdp3"),
+    new FreeRDPInstallation("sdl3-freerdp"),
 ];
 
 /**


### PR DESCRIPTION
close #646 

as per discussion in that issue: 

* I don't think we should check for sdl-freerdp3 on older systems:  It's unlikely to be better than X on them.
* I don't think we need to worry about xfreerdp3 on newer systems, it will likely not be present.  If it is present, it is highly likely that it should be removed, so even if the error shows up, it's a real error that the user should fix (by removing it.) so it's good information, and easily addressed.
* I don't think checking for presence of wayland is enough to make the decision to use it, and I don't think re-implementing logic already present in SDL itself is easy or helpful.

but those are all opinions... everybody can have different ideas... I made a PR in case someone thinks it's useful, or not... 

(copied on request from @Hi-Angel ) 
