### PR TITLE
Update Windows Docker image version to v6.05

### DIFF
--- a/src/renderer/data/docker.ts
+++ b/src/renderer/data/docker.ts
@@ -15,7 +15,7 @@ export const DOCKER_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:6.03",
+            image: "ghcr.io/dockur/windows:6.04",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",

--- a/src/renderer/data/docker.ts
+++ b/src/renderer/data/docker.ts
@@ -15,7 +15,7 @@ export const DOCKER_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:6.04",
+            image: "ghcr.io/dockur/windows:6.05",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",

--- a/src/renderer/data/podman.ts
+++ b/src/renderer/data/podman.ts
@@ -15,7 +15,7 @@ export const PODMAN_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:6.03",
+            image: "ghcr.io/dockur/windows:6.04",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",

--- a/src/renderer/data/podman.ts
+++ b/src/renderer/data/podman.ts
@@ -15,7 +15,7 @@ export const PODMAN_DEFAULT_COMPOSE: ComposeConfig = {
     },
     services: {
         windows: {
-            image: "ghcr.io/dockur/windows:6.04",
+            image: "ghcr.io/dockur/windows:6.05",
             container_name: "WinBoat",
             environment: {
                 VERSION: "11",


### PR DESCRIPTION
Updates base image to v6.05

This release contains more changes than ever, but the most noticeable will be that it does not need to rebuild the .iso file anymore. That skips the whole extracting/rebuilding phases after download, so it goes straight from download to booting the VM, which saves a lot of time (especially on slow storage).