### PR TITLE
fix: Validate rdpArgs shape on config load to prevent silent launch failure

### DIFF
--- a/src/renderer/lib/config.ts
+++ b/src/renderer/lib/config.ts
@@ -96,6 +96,45 @@ const defaultConfig: WinboatConfigObj = {
     appsSortOrder: 'name',
 };
 
+function isRdpArg(value: unknown): value is RdpArg {
+    if (typeof value !== "object" || value === null) return false;
+
+    const arg = value as Partial<RdpArg>;
+
+    return (
+        typeof arg.newArg === "string" &&
+        typeof arg.isReplacement === "boolean" &&
+        (arg.original === undefined || typeof arg.original === "string")
+    );
+}
+
+/**
+ * Drops `rdpArgs` entries that don't match {@link RdpArg}, such as the plain strings people tend to write
+ * when editing the config by hand. Without this, those entries travel all the way to the FreeRDP command
+ * line as `undefined` and every app launch fails without a single line of feedback.
+ */
+function sanitizeRdpArgs(configObj: WinboatConfigObj): void {
+    const rdpArgs: unknown = configObj.rdpArgs;
+
+    if (!Array.isArray(rdpArgs)) {
+        logger.error(
+            `Config key 'rdpArgs' must be an array, got ${JSON.stringify(rdpArgs)}. Using the default value instead.`,
+        );
+        configObj.rdpArgs = [...defaultConfig.rdpArgs];
+        return;
+    }
+
+    const invalidArgs = rdpArgs.filter(arg => !isRdpArg(arg));
+
+    if (!invalidArgs.length) return;
+
+    logger.error(
+        `Ignoring invalid 'rdpArgs' entries (${invalidArgs.length}): ${JSON.stringify(invalidArgs)}. ` +
+            `Each entry must be an object like { "newArg": "/sec:tls", "isReplacement": false }.`,
+    );
+    configObj.rdpArgs = rdpArgs.filter(isRdpArg);
+}
+
 export class WinboatConfig {
     private static readonly configPath: string = path.join(WINBOAT_DIR, "winboat.config.json");
     private static instance: WinboatConfig | null = null;
@@ -195,6 +234,8 @@ export class WinboatConfig {
                 fs.writeFileSync(WinboatConfig.configPath, JSON.stringify(configObj, null, 4), "utf-8");
                 console.log("Wrote updated config with missing keys to disk");
             }
+
+            sanitizeRdpArgs(configObj);
 
             return { ...configObj };
         } catch (e) {


### PR DESCRIPTION
## What and why

`winboat.config.json` is loaded without any shape validation. The loader only fills in keys that are missing, so when `rdpArgs` holds anything other than well formed `RdpArg` objects, the bad entries survive the load and reach the launch path untouched. There, `filter(a => a.isReplacement)` and `.map(v => v.newArg)` quietly produce `undefined`, the FreeRDP argument list ends up invalid, and the launch dies before anything is written to the log. The user sees nothing at all: no window, no dialog, no line in `winboat.log`.

The natural mistake is to write the extra arguments as plain strings, which is what both #836 and Discussion #595 ran into:

```json
"rdpArgs": ["/sec:tls"]
```

while the shape the app expects is an array of objects:

```json
"rdpArgs": [{ "newArg": "/sec:tls", "isReplacement": false }]
```

Nothing in the app says so and nothing complains when it is wrong, so the only way to find out is to grep `app.asar`.

## Reproduction

1. Install WinBoat 0.9.0 with a working Windows guest.
2. Set `"rdpArgs": ["/sec:tls"]` in `~/.winboat/winboat.config.json` by hand.
3. Restart WinBoat and open any app or the Windows Desktop.
4. Nothing happens, and `winboat.log` never reaches the point where the FreeRDP command line is composed.

## What this PR does

`WinboatConfig.readConfigObject()` now validates every `rdpArgs` entry after the defaults have been merged in:

- Entries that do not match `RdpArg` (`newArg: string`, `isReplacement: boolean`, optional `original: string`) are dropped, and a single `logger.error` names the discarded entries and the expected shape.
- A value that is not an array at all falls back to the default `[]`, also with a logged error.
- Well formed entries are left exactly as they are, so configs that work today keep behaving identically.

The sanitizing happens in memory only. The file on disk is left as the user wrote it, so the invalid entries stay visible for them to fix and nothing is silently rewritten underneath them.

The scope is deliberately narrow: one field, one guard, no new dependency, no change to the loader's existing behaviour. Validating the whole config against a schema would be a much bigger change and is probably worth discussing on its own.

## Testing done

The guard was exercised case by case against the source in this branch, on Node 23.11.1 and Bun 1.3.13:

| Input for `rdpArgs` | Result |
| --- | --- |
| `["/sec:tls"]` (the payload from the issue) | discarded, error logged, no `undefined` reaches the argument list |
| well formed array of objects | output identical to input, nothing logged |
| mixed array (1 valid, 2 invalid) | the valid entry survives, the 2 invalid ones are reported in one error |
| key absent from the file | default `[]`, nothing logged |
| value is a string instead of an array | default `[]`, error logged |
| entry with a non string `original` | discarded, error logged |

Build checks on the same toolchain:

- `bun install --frozen-lockfile`
- `vue-tsc --noEmit -p src/renderer/tsconfig.json` reports the same 41 diagnostics as `main` at 8cff1ac, none of them in `config.ts`
- `bun scripts/build.ts` exits 0, and the new guard is present in the production renderer bundle

I did not run `build:linux-gs`, since the change is renderer only and does not touch the guest server.

Fixes #836

Written with AI assistance (Claude), reviewed and tested by me before submitting.
