### PR TITLE
feat: Russian Comment and Keywords for the Linux desktop entry

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -21,7 +21,9 @@
         "artifactName": "${name}-${version}-${arch}.${ext}",
         "desktop": {
             "entry": {
-                "Comment[ru]": "Запуск приложений Windows в Linux с бесшовной интеграцией"
+                "Comment[ru]": "Запуск приложений Windows в Linux с бесшовной интеграцией",
+                "Keywords": "windows;vm;virtual machine;virtualization;rdp;freerdp;remoteapp;docker;kvm;apps;",
+                "Keywords[ru]": "windows;vm;rdp;freerdp;docker;kvm;виртуальная машина;виртуализация;приложения windows;программы;"
             }
         }
     },

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -18,7 +18,12 @@
         "icon": "icons/winboat_logo.svg",
         "target": ["appimage", "deb", "rpm", "tar.bz2"],
         "category": "Utility",
-        "artifactName": "${name}-${version}-${arch}.${ext}"
+        "artifactName": "${name}-${version}-${arch}.${ext}",
+        "desktop": {
+            "entry": {
+                "Comment[ru]": "Запуск приложений Windows в Linux с бесшовной интеграцией"
+            }
+        }
     },
     "files": [
         {


### PR DESCRIPTION
Updated: I was wrong in the first version of this PR, so the diff changed.

The launcher entry today has no Russian text at all. On a Russian desktop Kickoff (and GNOME's overview, and Cinnamon's menu) prints the app name on the first line and `Comment` on the second, so a Russian user gets "WinBoat" and then an English sentence, or nothing useful.

**What changed since the first push**

My original commit also set an English `Comment` inside `linux.desktop.entry`. That line does nothing. In `LinuxTargetHelper.computeDesktopEntry` the user's `desktop.entry` is merged first, and `desktopMeta.Comment` is assigned from `linux.description` (falling back to the package.json description) right after, so `Comment` is always overwritten. `Comment[ru]` is a different key and survives, which is why only that one is left here. The English line keeps coming from "Windows for Penguins" as before — I did not touch your tagline.

**Keywords**

The generated entry has `Name`, `Comment`, `Categories`, `Exec`, `Icon` and `StartupWMClass`, but no `Keywords`, so the launcher only finds WinBoat by its name. Someone typing "rdp", "virtual machine" or "docker" gets nothing. Second commit adds a list.

`Keywords[ru]` repeats the English terms on purpose. A Russian locale reads `Keywords[ru]` *instead of* `Keywords`, not in addition to it, so leaving the English words out would break searching for "rdp" or "freerdp" as soon as the desktop language is Russian. Technology names stay in Latin in the Russian string, the way people actually type them.

I left `StartupWMClass` alone — electron-builder already emits it.

Two commits, config only, no code paths touched. Happy to squash or reword if you prefer.
