### PR TITLE
fix: Recognize all auto-restart policies for Auto Start Container

### DIFF
--- a/src/renderer/lib/constants.ts
+++ b/src/renderer/lib/constants.ts
@@ -111,3 +111,14 @@ export const RESTART_UNLESS_STOPPED = "unless-stopped";
 export const RESTART_ON_FAILURE = "on-failure";
 export const RESTART_ALWAYS = "always";
 export const RESTART_NO = "no";
+
+/**
+ * Restart policies under which the container comes back up on its own.
+ * Legacy installs shipped `on-failure` as the default, so it has to be
+ * recognized here even though we never write it anymore.
+ */
+export const AUTOSTART_RESTART_POLICIES: string[] = [
+    RESTART_UNLESS_STOPPED,
+    RESTART_ALWAYS,
+    RESTART_ON_FAILURE,
+];

--- a/src/renderer/lib/constants.ts
+++ b/src/renderer/lib/constants.ts
@@ -112,13 +112,5 @@ export const RESTART_ON_FAILURE = "on-failure";
 export const RESTART_ALWAYS = "always";
 export const RESTART_NO = "no";
 
-/**
- * Restart policies under which the container comes back up on its own.
- * Legacy installs shipped `on-failure` as the default, so it has to be
- * recognized here even though we never write it anymore.
- */
-export const AUTOSTART_RESTART_POLICIES: string[] = [
-    RESTART_UNLESS_STOPPED,
-    RESTART_ALWAYS,
-    RESTART_ON_FAILURE,
-];
+/** Restart policies under which the container comes back up on its own */
+export const AUTOSTART_RESTART_POLICIES: string[] = [RESTART_UNLESS_STOPPED, RESTART_ALWAYS];

--- a/src/renderer/views/Config.vue
+++ b/src/renderer/views/Config.vue
@@ -475,10 +475,6 @@ const sharedFolderPath = ref("");
 const origSharedFolderPath = ref("");
 const origAutoStartContainer = ref(false);
 const autoStartContainer = ref(false);
-// True when the compose file holds a restart policy we no longer write (e.g. the
-// legacy `on-failure` default). Those can't be represented by the switch alone, so
-// we keep the Save button enabled to let the user normalize the policy.
-const hasLegacyRestartPolicy = ref(false);
 const isApplyingChanges = ref(false);
 const resetQuestionCounter = ref(0);
 const isResettingWinboat = ref(false);
@@ -531,7 +527,6 @@ async function assignValues() {
     const restartPolicy = compose.value.services.windows.restart;
     autoStartContainer.value = AUTOSTART_RESTART_POLICIES.includes(restartPolicy);
     origAutoStartContainer.value = autoStartContainer.value;
-    hasLegacyRestartPolicy.value = restartPolicy !== RESTART_UNLESS_STOPPED && restartPolicy !== RESTART_NO;
 
     const specs = await getSpecs();
     maxRamGB.value = specs.ramGB;
@@ -680,8 +675,7 @@ const saveButtonDisabled = computed(() => {
         origRamGB.value !== ramGB.value ||
         shareFolder.value !== origShareFolder.value ||
         sharedFolderPath.value !== origSharedFolderPath.value ||
-        autoStartContainer.value !== origAutoStartContainer.value ||
-        hasLegacyRestartPolicy.value;
+        autoStartContainer.value !== origAutoStartContainer.value;
 
     const shouldBeDisabled = errors.value?.length || !hasResourceChanges || isApplyingChanges.value;
 

--- a/src/renderer/views/Config.vue
+++ b/src/renderer/views/Config.vue
@@ -450,6 +450,7 @@ import {
     USB_VID_BLACKLIST,
     RESTART_UNLESS_STOPPED,
     RESTART_NO,
+    AUTOSTART_RESTART_POLICIES,
     GUEST_QMP_PORT,
     MIN_VM_RAM_GB,
     QMP_ARGUMENT,
@@ -474,6 +475,10 @@ const sharedFolderPath = ref("");
 const origSharedFolderPath = ref("");
 const origAutoStartContainer = ref(false);
 const autoStartContainer = ref(false);
+// True when the compose file holds a restart policy we no longer write (e.g. the
+// legacy `on-failure` default). Those can't be represented by the switch alone, so
+// we keep the Save button enabled to let the user normalize the policy.
+const hasLegacyRestartPolicy = ref(false);
 const isApplyingChanges = ref(false);
 const resetQuestionCounter = ref(0);
 const isResettingWinboat = ref(false);
@@ -521,8 +526,12 @@ async function assignValues() {
     origShareFolder.value = shareFolder.value;
     origSharedFolderPath.value = sharedFolderPath.value;
 
-    autoStartContainer.value = compose.value.services.windows.restart === RESTART_UNLESS_STOPPED;
+    // Any policy that makes the container come back on its own counts as auto start,
+    // not just the one we currently write out
+    const restartPolicy = compose.value.services.windows.restart;
+    autoStartContainer.value = AUTOSTART_RESTART_POLICIES.includes(restartPolicy);
     origAutoStartContainer.value = autoStartContainer.value;
+    hasLegacyRestartPolicy.value = restartPolicy !== RESTART_UNLESS_STOPPED && restartPolicy !== RESTART_NO;
 
     const specs = await getSpecs();
     maxRamGB.value = specs.ramGB;
@@ -671,7 +680,8 @@ const saveButtonDisabled = computed(() => {
         origRamGB.value !== ramGB.value ||
         shareFolder.value !== origShareFolder.value ||
         sharedFolderPath.value !== origSharedFolderPath.value ||
-        autoStartContainer.value !== origAutoStartContainer.value;
+        autoStartContainer.value !== origAutoStartContainer.value ||
+        hasLegacyRestartPolicy.value;
 
     const shouldBeDisabled = errors.value?.length || !hasResourceChanges || isApplyingChanges.value;
 


### PR DESCRIPTION
The Auto Start Container switch read the compose restart policy with a strict equality check against `unless-stopped`, so the two other policies that also bring the container back on their own (`always` and the legacy `on-failure` default) rendered as OFF.

Installs created before 4fefd6d shipped `restart: on-failure`. For those users the switch showed OFF while Docker still restarted the container, and because `origAutoStartContainer` matched, the Save button stayed disabled - leaving no in-app way to write `restart: no`.

Read the policy against a shared AUTOSTART_RESTART_POLICIES list instead, and track whether the on-disk policy is non-canonical so Save stays reachable and one save normalizes the file to `unless-stopped` or `no`.

Fixes #474
