### PR TITLE
feat(guest): add bounded icon-free app projection

### DIFF
--- a/build-guest-server.sh
+++ b/build-guest-server.sh
@@ -53,8 +53,28 @@ go build -ldflags="${LDFLAGS[*]}" -o "$DIST/oem/server/winboat_guest_server.exe"
 echo "Building guest server updater..."
 go build -ldflags="${LDFLAGS[*]}" -o "$DIST/oem/updater/winboat_guest_server_updater.exe" ./cmd/updater
 
-# Runtime assets that ship inside server\ (these get updated alongside the exe)
-cp scripts/apps.ps1 scripts/get-icon.ps1 scripts/time-sync.bat "$DIST/oem/server/scripts/"
+# Runtime assets that ship inside server\ (these get updated alongside the exe).
+# Copy every runtime script so anything the server invokes at runtime — including
+# the projected apps-query.ps1 — is always packaged and can never silently drift
+# from the source tree.
+cp scripts/*.ps1 scripts/*.bat "$DIST/oem/server/scripts/"
+
+# Guard against packaging drift: fail the build if the server binaries reference a
+# script that was not placed into the package. Without this, the server can
+# advertise a capability (e.g. apps-query-v1) whose backing script is missing on
+# the Guest, and every projected request fails at runtime.
+missing_scripts=0
+for referenced in $(grep -rhoE 'scripts\\\\[A-Za-z0-9._-]+\.(ps1|bat)' cmd | sed -E 's/.*scripts\\\\//' | sort -u); do
+    if [ ! -f "$DIST/oem/server/scripts/$referenced" ]; then
+        echo "✗ Packaged server is missing referenced script: $referenced"
+        missing_scripts=1
+    fi
+done
+if [ "$missing_scripts" -ne 0 ]; then
+    echo "✗ Guest server packaging is incomplete; aborting."
+    exit 1
+fi
+echo "✓ All server-referenced scripts are packaged"
 
 # Install-time assets that live at the OEM/install root
 cp install.bat nssm.exe RDPApps.reg "$DIST/oem/"

--- a/build-guest-server.sh
+++ b/build-guest-server.sh
@@ -54,10 +54,15 @@ echo "Building guest server updater..."
 go build -ldflags="${LDFLAGS[*]}" -o "$DIST/oem/updater/winboat_guest_server_updater.exe" ./cmd/updater
 
 # Runtime assets that ship inside server\ (these get updated alongside the exe).
-# Copy every runtime script so anything the server invokes at runtime — including
-# the projected apps-query.ps1 — is always packaged and can never silently drift
-# from the source tree.
-cp scripts/*.ps1 scripts/*.bat "$DIST/oem/server/scripts/"
+# Keep this allowlist explicit because the Guest service runs as SYSTEM; source-only
+# helper or test scripts must never enter a release package by glob expansion.
+runtime_scripts=(
+    scripts/apps.ps1
+    scripts/apps-query.ps1
+    scripts/get-icon.ps1
+    scripts/time-sync.bat
+)
+cp "${runtime_scripts[@]}" "$DIST/oem/server/scripts/"
 
 # Guard against packaging drift: fail the build if the server binaries reference a
 # script that was not placed into the package. Without this, the server can

--- a/guest_server/API.md
+++ b/guest_server/API.md
@@ -1,0 +1,58 @@
+# WinBoat Guest API
+
+## Capability discovery
+
+`GET /health` is intentionally unauthenticated so a loopback host can check
+readiness before it has loaded the shared Guest token. In addition to
+`{"status":"ok"}`, current servers return an API version, authentication
+scheme, and a list of versioned capabilities:
+
+```json
+{
+  "status": "ok",
+  "apiVersion": 1,
+  "authentication": "bearer",
+  "capabilities": ["apps-query-v1"]
+}
+```
+
+Unknown capability names must be ignored. Clients may use a capability only
+after it is advertised. Existing Guest versions that return only `status`
+remain valid.
+
+## Bounded app projection
+
+`apps-query-v1` adds a filtered, icon-free form of the existing authenticated
+`GET /apps` endpoint. It is intended for callers that need to discover a small
+set of executables under a known installation root without generating every
+application icon.
+
+All of the following query parameters are required except `limit`:
+
+| Parameter | Contract |
+| --- | --- |
+| `includeIcons` | Must be `false`. The projected path never loads or encodes icons. |
+| `pathPrefix` | Local absolute Windows directory containing immediate child installation directories. UNC paths, control characters, wildcards, traversal, and paths over 4 KiB are rejected. |
+| `pathSuffix` | Relative executable path below each immediate child of `pathPrefix`, beginning with `\`. The same path restrictions apply. |
+| `fields` | Comma-separated projection of `Name`, `Path`, and `Source`; `Path` is required. Unknown and duplicate fields are rejected. |
+| `limit` | Optional integer from 1 through 128; defaults to 128. |
+
+For example:
+
+```text
+GET /apps?includeIcons=false&pathPrefix=C%3A%5CProgram%20Files%5CMendix%5C&pathSuffix=%5Cmodeler%5Cstudiopro.exe&fields=Name%2CPath%2CSource&limit=128
+Authorization: Bearer <shared guest token>
+```
+
+The response is always a JSON array, including when zero or one app matches.
+The server checks only `pathPrefix/<immediate child>/<pathSuffix>`, rejects
+reparse points at every traversed component, resolves an existing leaf, and
+returns at most `limit` entries. Execution is limited to 10 seconds and the
+serialized response to 256 KiB. Invalid queries return 400, authentication
+failures return 401, timeouts return 504, and execution or response-limit
+failures return 500.
+
+A request without projected-query parameters retains the original `/apps`
+behavior. It has a 30-second execution limit and an 8 MiB response limit.
+Clients should use this legacy request only when `apps-query-v1` is absent;
+they should not downgrade after an advertised projected request fails.

--- a/guest_server/API.md
+++ b/guest_server/API.md
@@ -32,9 +32,9 @@ All of the following query parameters are required except `limit`:
 | Parameter | Contract |
 | --- | --- |
 | `includeIcons` | Must be `false`. The projected path never loads or encodes icons. |
-| `pathPrefix` | Local absolute Windows directory containing immediate child installation directories. UNC paths, control characters, wildcards, traversal, and paths over 4 KiB are rejected. |
+| `pathPrefix` | Local absolute Windows directory containing immediate child installation directories. UNC paths, control characters, wildcards, traversal, invalid Windows path characters, trailing dots or spaces in components, and paths over 4 KiB are rejected. |
 | `pathSuffix` | Relative executable path below each immediate child of `pathPrefix`, beginning with `\`. The same path restrictions apply. |
-| `fields` | Comma-separated projection of `Name`, `Path`, and `Source`; `Path` is required. Unknown and duplicate fields are rejected. |
+| `fields` | Comma-separated projection of `Name`, `Path`, and `Source`, bounded to 128 bytes; `Path` is required. Unknown, duplicate, and control-character fields are rejected. |
 | `limit` | Optional integer from 1 through 128; defaults to 128. |
 
 For example:
@@ -46,7 +46,8 @@ Authorization: Bearer <shared guest token>
 
 The response is always a JSON array, including when zero or one app matches.
 The server checks only `pathPrefix/<immediate child>/<pathSuffix>`, rejects
-reparse points at every traversed component, resolves an existing leaf, and
+reparse points at every traversed component including ancestors of
+`pathPrefix`, resolves an existing leaf, and
 returns at most `limit` entries. Execution is limited to 10 seconds and the
 serialized response to 256 KiB. Invalid queries return 400, authentication
 failures return 401, timeouts return 504, and execution or response-limit

--- a/guest_server/API.md
+++ b/guest_server/API.md
@@ -54,6 +54,6 @@ failures return 401, timeouts return 504, and execution or response-limit
 failures return 500.
 
 A request without projected-query parameters retains the original `/apps`
-behavior. It has a 30-second execution limit and an 8 MiB response limit.
-Clients should use this legacy request only when `apps-query-v1` is absent;
-they should not downgrade after an advertised projected request fails.
+behavior, including its existing execution and response semantics. Clients
+should use this legacy request only when `apps-query-v1` is absent; they should
+not downgrade after an advertised projected request fails.

--- a/guest_server/cmd/server/apps_handler_test.go
+++ b/guest_server/cmd/server/apps_handler_test.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAppsHandlerRejectsInvalidQueriesBeforeExecution(t *testing.T) {
+	for _, rawQuery := range []string{
+		"command=whoami",
+		"includeIcons=false&pathPrefix=%zz",
+		"includeIcons=true&pathPrefix=C%3A%5CApps%5C&pathSuffix=%5Capp.exe&fields=Path",
+	} {
+		request := httptest.NewRequest(http.MethodGet, "/apps?"+rawQuery, nil)
+		response := httptest.NewRecorder()
+
+		getApps(response, request)
+
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("GET /apps?%s status = %d, want %d", rawQuery, response.Code, http.StatusBadRequest)
+		}
+	}
+}
+
+func TestHealthAdvertisesTheVersionedAppsCapability(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	response := httptest.NewRecorder()
+
+	getHealth(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET /health status = %d, want %d", response.Code, http.StatusOK)
+	}
+	var payload struct {
+		Status         string   `json:"status"`
+		APIVersion     int      `json:"apiVersion"`
+		Authentication string   `json:"authentication"`
+		Capabilities   []string `json:"capabilities"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode GET /health response: %v", err)
+	}
+	if payload.Status != "ok" ||
+		payload.APIVersion != 1 ||
+		payload.Authentication != "bearer" ||
+		len(payload.Capabilities) != 1 ||
+		payload.Capabilities[0] != appsQueryCapability {
+		t.Fatalf("unexpected GET /health response: %#v", payload)
+	}
+}

--- a/guest_server/cmd/server/apps_query.go
+++ b/guest_server/cmd/server/apps_query.go
@@ -13,6 +13,7 @@ const (
 	defaultAppsLimit    = 128
 	maxAppsLimit        = 128
 	maxAppsPathBytes    = 4096
+	maxAppsFieldsBytes  = 128
 )
 
 var projectedAppFields = map[string]string{
@@ -39,14 +40,7 @@ type appsQuery struct {
 
 func parseAppsQuery(values url.Values) (appsQuery, error) {
 	query := appsQuery{}
-	known := false
-	for _, key := range []string{"includeIcons", "pathPrefix", "pathSuffix", "fields", "limit"} {
-		if values.Has(key) {
-			known = true
-			break
-		}
-	}
-	if !known {
+	if len(values) == 0 {
 		return query, nil
 	}
 	for key, entries := range values {
@@ -58,8 +52,7 @@ func parseAppsQuery(values url.Values) (appsQuery, error) {
 		}
 	}
 
-	includeIcons, err := strconv.ParseBool(values.Get("includeIcons"))
-	if err != nil || includeIcons {
+	if values.Get("includeIcons") != "false" {
 		return appsQuery{}, errors.New("includeIcons=false is required for projected app queries")
 	}
 	pathPrefix := values.Get("pathPrefix")
@@ -91,9 +84,20 @@ func parseAppsQuery(values url.Values) (appsQuery, error) {
 	}, nil
 }
 
+func parseAppsRawQuery(rawQuery string) (appsQuery, error) {
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return appsQuery{}, errors.New("projected app query is malformed")
+	}
+	return parseAppsQuery(values)
+}
+
 func parseProjectedFields(raw string) ([]string, error) {
 	if raw == "" {
 		return nil, errors.New("fields is required for projected app queries")
+	}
+	if len(raw) > maxAppsFieldsBytes || strings.ContainsFunc(raw, unicode.IsControl) {
+		return nil, errors.New("fields exceeds the safe limits")
 	}
 	seen := make(map[string]struct{})
 	fields := make([]string, 0, len(projectedAppFields))
@@ -118,6 +122,9 @@ func isSafeWindowsRoot(value string) bool {
 	if len(value) < 3 || len(value) > maxAppsPathBytes || !isASCIIAlpha(value[0]) || value[1] != ':' || !isPathSeparator(value[2]) {
 		return false
 	}
+	if len(value) == 3 {
+		return true
+	}
 	return safeWindowsPathComponents(value[3:])
 }
 
@@ -129,7 +136,7 @@ func isSafeRelativeWindowsSuffix(value string) bool {
 }
 
 func safeWindowsPathComponents(value string) bool {
-	if value == "" || strings.ContainsAny(value, "*?\"") || strings.ContainsRune(value, ':') || strings.ContainsFunc(value, unicode.IsControl) {
+	if value == "" || strings.ContainsAny(value, "*?\"<>|") || strings.ContainsRune(value, ':') || strings.ContainsFunc(value, unicode.IsControl) {
 		return false
 	}
 	components := strings.FieldsFunc(value, func(r rune) bool { return r == '\\' || r == '/' })
@@ -137,7 +144,11 @@ func safeWindowsPathComponents(value string) bool {
 		return false
 	}
 	for _, component := range components {
-		if component == "." || component == ".." || strings.TrimSpace(component) == "" {
+		trimmed := strings.TrimSpace(component)
+		if trimmed == "" ||
+			component == "." ||
+			component == ".." ||
+			strings.TrimRight(component, " .") != component {
 			return false
 		}
 	}

--- a/guest_server/cmd/server/apps_query.go
+++ b/guest_server/cmd/server/apps_query.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"errors"
+	"net/url"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const (
+	appsQueryCapability = "apps-query-v1"
+	defaultAppsLimit    = 128
+	maxAppsLimit        = 128
+	maxAppsPathBytes    = 4096
+)
+
+var projectedAppFields = map[string]string{
+	"name":   "Name",
+	"path":   "Path",
+	"source": "Source",
+}
+
+var appsQueryParameters = map[string]struct{}{
+	"includeIcons": {},
+	"pathPrefix":   {},
+	"pathSuffix":   {},
+	"fields":       {},
+	"limit":        {},
+}
+
+type appsQuery struct {
+	projected  bool
+	pathPrefix string
+	pathSuffix string
+	fields     []string
+	limit      int
+}
+
+func parseAppsQuery(values url.Values) (appsQuery, error) {
+	query := appsQuery{}
+	known := false
+	for _, key := range []string{"includeIcons", "pathPrefix", "pathSuffix", "fields", "limit"} {
+		if values.Has(key) {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return query, nil
+	}
+	for key, entries := range values {
+		if _, ok := appsQueryParameters[key]; !ok {
+			return appsQuery{}, errors.New("projected app query contains an unsupported parameter")
+		}
+		if len(entries) != 1 {
+			return appsQuery{}, errors.New("projected app query parameters must not be repeated")
+		}
+	}
+
+	includeIcons, err := strconv.ParseBool(values.Get("includeIcons"))
+	if err != nil || includeIcons {
+		return appsQuery{}, errors.New("includeIcons=false is required for projected app queries")
+	}
+	pathPrefix := values.Get("pathPrefix")
+	pathSuffix := values.Get("pathSuffix")
+	if !isSafeWindowsRoot(pathPrefix) {
+		return appsQuery{}, errors.New("pathPrefix must be a bounded local absolute Windows path")
+	}
+	if !isSafeRelativeWindowsSuffix(pathSuffix) {
+		return appsQuery{}, errors.New("pathSuffix must be a bounded relative Windows path")
+	}
+	fields, err := parseProjectedFields(values.Get("fields"))
+	if err != nil {
+		return appsQuery{}, err
+	}
+	limit := defaultAppsLimit
+	if rawLimit := values.Get("limit"); rawLimit != "" {
+		limit, err = strconv.Atoi(rawLimit)
+		if err != nil || limit < 1 || limit > maxAppsLimit {
+			return appsQuery{}, errors.New("limit must be between 1 and 128")
+		}
+	}
+
+	return appsQuery{
+		projected:  true,
+		pathPrefix: pathPrefix,
+		pathSuffix: pathSuffix,
+		fields:     fields,
+		limit:      limit,
+	}, nil
+}
+
+func parseProjectedFields(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, errors.New("fields is required for projected app queries")
+	}
+	seen := make(map[string]struct{})
+	fields := make([]string, 0, len(projectedAppFields))
+	for _, rawField := range strings.Split(raw, ",") {
+		field, ok := projectedAppFields[strings.ToLower(strings.TrimSpace(rawField))]
+		if !ok {
+			return nil, errors.New("fields contains an unsupported projection")
+		}
+		if _, duplicate := seen[field]; duplicate {
+			return nil, errors.New("fields contains a duplicate projection")
+		}
+		seen[field] = struct{}{}
+		fields = append(fields, field)
+	}
+	if _, ok := seen["Path"]; !ok {
+		return nil, errors.New("fields must include Path")
+	}
+	return fields, nil
+}
+
+func isSafeWindowsRoot(value string) bool {
+	if len(value) < 3 || len(value) > maxAppsPathBytes || !isASCIIAlpha(value[0]) || value[1] != ':' || !isPathSeparator(value[2]) {
+		return false
+	}
+	return safeWindowsPathComponents(value[3:])
+}
+
+func isSafeRelativeWindowsSuffix(value string) bool {
+	if len(value) < 2 || len(value) > maxAppsPathBytes || !isPathSeparator(value[0]) {
+		return false
+	}
+	return safeWindowsPathComponents(value[1:])
+}
+
+func safeWindowsPathComponents(value string) bool {
+	if value == "" || strings.ContainsAny(value, "*?\"") || strings.ContainsRune(value, ':') || strings.ContainsFunc(value, unicode.IsControl) {
+		return false
+	}
+	components := strings.FieldsFunc(value, func(r rune) bool { return r == '\\' || r == '/' })
+	if len(components) == 0 {
+		return false
+	}
+	for _, component := range components {
+		if component == "." || component == ".." || strings.TrimSpace(component) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIIAlpha(value byte) bool {
+	return value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}
+
+func isPathSeparator(value byte) bool {
+	return value == '\\' || value == '/'
+}
+
+func (query appsQuery) powerShellArgs() []string {
+	return []string{
+		"-PathPrefix", query.pathPrefix,
+		"-PathSuffix", query.pathSuffix,
+		"-Fields", strings.Join(query.fields, ","),
+		"-Limit", strconv.Itoa(query.limit),
+	}
+}

--- a/guest_server/cmd/server/apps_query_test.go
+++ b/guest_server/cmd/server/apps_query_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -22,6 +23,16 @@ func TestParseAppsQuery(t *testing.T) {
 				"pathSuffix":   {`\modeler\studiopro.exe`},
 				"fields":       {"Name,Path,Source"},
 				"limit":        {"64"},
+			},
+			projected: true,
+		},
+		{
+			name: "drive root projection",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\`},
+				"pathSuffix":   {`\modeler\studiopro.exe`},
+				"fields":       {"Name,Path,Source"},
 			},
 			projected: true,
 		},
@@ -87,6 +98,81 @@ func TestParseAppsQuery(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:    "unknown parameter alone",
+			values:  url.Values{"command": {"whoami"}},
+			wantErr: true,
+		},
+		{
+			name: "repeated parameter",
+			values: url.Values{
+				"includeIcons": {"false", "false"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-canonical false value",
+			values: url.Values{
+				"includeIcons": {"0"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "oversized fields",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {strings.Repeat("Path,", maxAppsFieldsBytes)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "control character in fields",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path,\nName"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "traversal with normalized trailing space",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\.. \secret.exe`},
+				"fields":       {"Path"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "trailing dot component",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\Apps.\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid Windows path character",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\App|s\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -99,6 +185,12 @@ func TestParseAppsQuery(t *testing.T) {
 				t.Fatalf("parseAppsQuery() projected = %v, want %v", query.projected, test.projected)
 			}
 		})
+	}
+}
+
+func TestParseAppsRawQueryRejectsMalformedEscaping(t *testing.T) {
+	if _, err := parseAppsRawQuery("includeIcons=false&pathPrefix=%zz"); err == nil {
+		t.Fatal("parseAppsRawQuery() accepted malformed percent escaping")
 	}
 }
 

--- a/guest_server/cmd/server/apps_query_test.go
+++ b/guest_server/cmd/server/apps_query_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestParseAppsQuery(t *testing.T) {
+	tests := []struct {
+		name      string
+		values    url.Values
+		projected bool
+		wantErr   bool
+	}{
+		{name: "legacy request", values: url.Values{}},
+		{
+			name: "bounded projection",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\Program Files\Mendix\`},
+				"pathSuffix":   {`\modeler\studiopro.exe`},
+				"fields":       {"Name,Path,Source"},
+				"limit":        {"64"},
+			},
+			projected: true,
+		},
+		{
+			name: "icons cannot be requested",
+			values: url.Values{
+				"includeIcons": {"true"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "UNC root",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`\\server\share`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "relative traversal",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\..\secret.exe`},
+				"fields":       {"Path"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown field",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path,Icon"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "oversized limit",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path"},
+				"limit":        {"129"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown parameter",
+			values: url.Values{
+				"includeIcons": {"false"},
+				"pathPrefix":   {`C:\Apps\`},
+				"pathSuffix":   {`\app.exe`},
+				"fields":       {"Path"},
+				"command":      {"whoami"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query, err := parseAppsQuery(test.values)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("parseAppsQuery() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if query.projected != test.projected {
+				t.Fatalf("parseAppsQuery() projected = %v, want %v", query.projected, test.projected)
+			}
+		})
+	}
+}
+
+func TestProjectedQueryPowerShellArgumentsStaySeparated(t *testing.T) {
+	query, err := parseAppsQuery(url.Values{
+		"includeIcons": {"false"},
+		"pathPrefix":   {`C:\Program Files\Mendix\`},
+		"pathSuffix":   {`\modeler\studiopro.exe`},
+		"fields":       {"Name,Path,Source"},
+		"limit":        {"64"},
+	})
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	want := []string{
+		"-PathPrefix", `C:\Program Files\Mendix\`,
+		"-PathSuffix", `\modeler\studiopro.exe`,
+		"-Fields", "Name,Path,Source",
+		"-Limit", "64",
+	}
+	if got := query.powerShellArgs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("powerShellArgs() = %#v, want %#v", got, want)
+	}
+}

--- a/guest_server/cmd/server/main.go
+++ b/guest_server/cmd/server/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -22,6 +23,13 @@ var (
 	Version        = "0.0.0"
 	CommitHash     = "n/a"
 	BuildTimestamp = "n/a"
+)
+
+const (
+	appsRequestTimeout        = 30 * time.Second
+	projectedAppsTimeout      = 10 * time.Second
+	maxAppsResponseBytes      = 8 << 20
+	maxProjectedResponseBytes = 256 << 10
 )
 
 type Metrics struct {
@@ -46,9 +54,40 @@ type RDPStatusResponse struct {
 }
 
 func getApps(w http.ResponseWriter, r *http.Request) {
-	output, err := executePowerShellScript(".\\scripts\\apps.ps1", true)
+	query, err := parseAppsQuery(r.URL.Query())
 	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	script := ".\\scripts\\apps.ps1"
+	timeout := appsRequestTimeout
+	maxResponseBytes := maxAppsResponseBytes
+	var args []string
+	if query.projected {
+		script = ".\\scripts\\apps-query.ps1"
+		timeout = projectedAppsTimeout
+		maxResponseBytes = maxProjectedResponseBytes
+		args = query.powerShellArgs()
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+	var output []byte
+	if query.projected {
+		output, err = executePowerShellScriptWithNamedArgsContext(ctx, script, args...)
+	} else {
+		output, err = executePowerShellScriptContext(ctx, script, true)
+	}
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			http.Error(w, "App discovery timed out", http.StatusGatewayTimeout)
+			return
+		}
 		http.Error(w, "Failed to execute script: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(output) > maxResponseBytes {
+		http.Error(w, "App discovery response exceeds the safe size limit", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -57,7 +96,17 @@ func getApps(w http.ResponseWriter, r *http.Request) {
 }
 
 func getHealth(w http.ResponseWriter, r *http.Request) {
-	response := map[string]string{"status": "ok"}
+	response := struct {
+		Status         string   `json:"status"`
+		APIVersion     int      `json:"apiVersion"`
+		Authentication string   `json:"authentication"`
+		Capabilities   []string `json:"capabilities"`
+	}{
+		Status:         "ok",
+		APIVersion:     1,
+		Authentication: "bearer",
+		Capabilities:   []string{appsQueryCapability},
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(response)

--- a/guest_server/cmd/server/main.go
+++ b/guest_server/cmd/server/main.go
@@ -26,9 +26,7 @@ var (
 )
 
 const (
-	appsRequestTimeout        = 30 * time.Second
 	projectedAppsTimeout      = 10 * time.Second
-	maxAppsResponseBytes      = 8 << 20
 	maxProjectedResponseBytes = 256 << 10
 )
 
@@ -60,24 +58,26 @@ func getApps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	script := ".\\scripts\\apps.ps1"
-	timeout := appsRequestTimeout
-	maxResponseBytes := maxAppsResponseBytes
-	var args []string
-	if query.projected {
-		script = ".\\scripts\\apps-query.ps1"
-		timeout = projectedAppsTimeout
-		maxResponseBytes = maxProjectedResponseBytes
-		args = query.powerShellArgs()
+	if !query.projected {
+		// Preserve the query-less endpoint exactly for existing WinBoat clients.
+		// Only the advertised projected capability receives the new bounds.
+		output, err := executePowerShellScript(".\\scripts\\apps.ps1", true)
+		if err != nil {
+			http.Error(w, "Failed to execute script: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, output)
+		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+
+	ctx, cancel := context.WithTimeout(r.Context(), projectedAppsTimeout)
 	defer cancel()
-	var output []byte
-	if query.projected {
-		output, err = executePowerShellScriptWithNamedArgsContextBounded(ctx, script, maxResponseBytes, args...)
-	} else {
-		output, err = executePowerShellScriptContextBounded(ctx, script, true, maxResponseBytes)
-	}
+	output, err := executePowerShellScriptWithNamedArgsContextBounded(
+		ctx,
+		".\\scripts\\apps-query.ps1",
+		maxProjectedResponseBytes,
+		query.powerShellArgs()...,
+	)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			http.Error(w, "App discovery timed out", http.StatusGatewayTimeout)
@@ -86,10 +86,10 @@ func getApps(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to execute script: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if len(output) > maxResponseBytes {
-		http.Error(w, "App discovery response exceeds the safe size limit", http.StatusInternalServerError)
-		return
-	}
+	writeJSON(w, output)
+}
+
+func writeJSON(w http.ResponseWriter, output []byte) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	w.Write(output)

--- a/guest_server/cmd/server/main.go
+++ b/guest_server/cmd/server/main.go
@@ -54,7 +54,7 @@ type RDPStatusResponse struct {
 }
 
 func getApps(w http.ResponseWriter, r *http.Request) {
-	query, err := parseAppsQuery(r.URL.Query())
+	query, err := parseAppsRawQuery(r.URL.RawQuery)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -74,9 +74,9 @@ func getApps(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	var output []byte
 	if query.projected {
-		output, err = executePowerShellScriptWithNamedArgsContext(ctx, script, args...)
+		output, err = executePowerShellScriptWithNamedArgsContextBounded(ctx, script, maxResponseBytes, args...)
 	} else {
-		output, err = executePowerShellScriptContext(ctx, script, true)
+		output, err = executePowerShellScriptContextBounded(ctx, script, true, maxResponseBytes)
 	}
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {

--- a/guest_server/cmd/server/util.go
+++ b/guest_server/cmd/server/util.go
@@ -3,11 +3,17 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 )
 
 func executePowerShellScript(script string, utf8Out bool, args ...string) ([]byte, error) {
+	return executePowerShellScriptContext(context.Background(), script, utf8Out, args...)
+}
+
+func executePowerShellScriptContext(ctx context.Context, script string, utf8Out bool, args ...string) ([]byte, error) {
 	powerShellArgs := []string{"-ExecutionPolicy", "Bypass"}
 	if utf8Out {
 		command := "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; & " + quotePowerShellArgument(script)
@@ -20,7 +26,38 @@ func executePowerShellScript(script string, utf8Out bool, args ...string) ([]byt
 		powerShellArgs = append(powerShellArgs, args...)
 	}
 
-	return exec.Command("powershell", powerShellArgs...).Output()
+	return commandOutput(ctx, powerShellArgs)
+}
+
+func executePowerShellScriptWithNamedArgsContext(ctx context.Context, script string, args ...string) ([]byte, error) {
+	if len(args)%2 != 0 {
+		return nil, fmt.Errorf("PowerShell named arguments must be pairs")
+	}
+	command := "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; & " + quotePowerShellArgument(script)
+	for index := 0; index < len(args); index += 2 {
+		name := args[index]
+		if !isPowerShellParameterName(name) {
+			return nil, fmt.Errorf("invalid PowerShell parameter name")
+		}
+		command += " " + name + " " + quotePowerShellArgument(args[index+1])
+	}
+	return commandOutput(ctx, []string{"-ExecutionPolicy", "Bypass", "-Command", command})
+}
+
+func commandOutput(ctx context.Context, powerShellArgs []string) ([]byte, error) {
+	return exec.CommandContext(ctx, "powershell", powerShellArgs...).Output()
+}
+
+func isPowerShellParameterName(value string) bool {
+	if len(value) < 2 || len(value) > 64 || value[0] != '-' {
+		return false
+	}
+	for _, character := range value[1:] {
+		if !((character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z')) {
+			return false
+		}
+	}
+	return true
 }
 
 func quotePowerShellArgument(value string) string {

--- a/guest_server/cmd/server/util.go
+++ b/guest_server/cmd/server/util.go
@@ -3,17 +3,25 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
 )
+
+var errPowerShellOutputLimit = errors.New("PowerShell output exceeds the safe size limit")
 
 func executePowerShellScript(script string, utf8Out bool, args ...string) ([]byte, error) {
 	return executePowerShellScriptContext(context.Background(), script, utf8Out, args...)
 }
 
 func executePowerShellScriptContext(ctx context.Context, script string, utf8Out bool, args ...string) ([]byte, error) {
+	return executePowerShellScriptContextBounded(ctx, script, utf8Out, 0, args...)
+}
+
+func executePowerShellScriptContextBounded(ctx context.Context, script string, utf8Out bool, maxOutputBytes int, args ...string) ([]byte, error) {
 	powerShellArgs := []string{"-ExecutionPolicy", "Bypass"}
 	if utf8Out {
 		command := "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; & " + quotePowerShellArgument(script)
@@ -26,10 +34,14 @@ func executePowerShellScriptContext(ctx context.Context, script string, utf8Out 
 		powerShellArgs = append(powerShellArgs, args...)
 	}
 
-	return commandOutput(ctx, powerShellArgs)
+	return commandOutputBounded(ctx, powerShellArgs, maxOutputBytes)
 }
 
 func executePowerShellScriptWithNamedArgsContext(ctx context.Context, script string, args ...string) ([]byte, error) {
+	return executePowerShellScriptWithNamedArgsContextBounded(ctx, script, 0, args...)
+}
+
+func executePowerShellScriptWithNamedArgsContextBounded(ctx context.Context, script string, maxOutputBytes int, args ...string) ([]byte, error) {
 	if len(args)%2 != 0 {
 		return nil, fmt.Errorf("PowerShell named arguments must be pairs")
 	}
@@ -41,11 +53,41 @@ func executePowerShellScriptWithNamedArgsContext(ctx context.Context, script str
 		}
 		command += " " + name + " " + quotePowerShellArgument(args[index+1])
 	}
-	return commandOutput(ctx, []string{"-ExecutionPolicy", "Bypass", "-Command", command})
+	return commandOutputBounded(ctx, []string{"-ExecutionPolicy", "Bypass", "-Command", command}, maxOutputBytes)
 }
 
-func commandOutput(ctx context.Context, powerShellArgs []string) ([]byte, error) {
-	return exec.CommandContext(ctx, "powershell", powerShellArgs...).Output()
+func commandOutputBounded(ctx context.Context, powerShellArgs []string, maxOutputBytes int) ([]byte, error) {
+	if maxOutputBytes <= 0 {
+		return exec.CommandContext(ctx, "powershell", powerShellArgs...).Output()
+	}
+	output := boundedOutput{limit: maxOutputBytes}
+	command := exec.CommandContext(ctx, "powershell", powerShellArgs...)
+	command.Stdout = &output
+	if err := command.Run(); err != nil {
+		return nil, err
+	}
+	if output.exceeded {
+		return nil, errPowerShellOutputLimit
+	}
+	return output.Bytes(), nil
+}
+
+type boundedOutput struct {
+	bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (output *boundedOutput) Write(data []byte) (int, error) {
+	available := output.limit - output.Len()
+	if available > 0 {
+		count := min(available, len(data))
+		_, _ = output.Buffer.Write(data[:count])
+	}
+	if len(data) > available {
+		output.exceeded = true
+	}
+	return len(data), nil
 }
 
 func isPowerShellParameterName(value string) bool {

--- a/guest_server/cmd/server/util_test.go
+++ b/guest_server/cmd/server/util_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import "testing"
+
+func TestPowerShellParameterNamesAreStrictlyAllowlisted(t *testing.T) {
+	for _, value := range []string{"-PathPrefix", "-Limit"} {
+		if !isPowerShellParameterName(value) {
+			t.Fatalf("expected %q to be accepted", value)
+		}
+	}
+	for _, value := range []string{"PathPrefix", "-Path Prefix", "-Path;whoami", "--", "-경로"} {
+		if isPowerShellParameterName(value) {
+			t.Fatalf("expected %q to be rejected", value)
+		}
+	}
+}
+
+func TestPowerShellValuesEscapeSingleQuotes(t *testing.T) {
+	if got, want := quotePowerShellArgument(`C:\Apps\O'Brien`), `'C:\Apps\O''Brien'`; got != want {
+		t.Fatalf("quotePowerShellArgument() = %q, want %q", got, want)
+	}
+}

--- a/guest_server/cmd/server/util_test.go
+++ b/guest_server/cmd/server/util_test.go
@@ -22,3 +22,19 @@ func TestPowerShellValuesEscapeSingleQuotes(t *testing.T) {
 		t.Fatalf("quotePowerShellArgument() = %q, want %q", got, want)
 	}
 }
+
+func TestBoundedOutputRetainsOnlyTheLimit(t *testing.T) {
+	output := boundedOutput{limit: 5}
+	if count, err := output.Write([]byte("abc")); err != nil || count != 3 {
+		t.Fatalf("first Write() = %d, %v", count, err)
+	}
+	if count, err := output.Write([]byte("defg")); err != nil || count != 4 {
+		t.Fatalf("second Write() = %d, %v", count, err)
+	}
+	if got, want := output.String(), "abcde"; got != want {
+		t.Fatalf("bounded output = %q, want %q", got, want)
+	}
+	if !output.exceeded {
+		t.Fatal("bounded output did not record overflow")
+	}
+}

--- a/guest_server/scripts/apps-query.ps1
+++ b/guest_server/scripts/apps-query.ps1
@@ -17,6 +17,9 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $root = $PathPrefix.TrimEnd('\', '/')
+if ($root.Length -eq 2 -and $root[1] -eq ':') {
+    $root += '\'
+}
 $relativePath = $PathSuffix.TrimStart('\', '/')
 $selectedFields = @($Fields.Split(',') | ForEach-Object { $_.Trim() })
 $apps = [System.Collections.Generic.List[PSCustomObject]]::new()
@@ -27,11 +30,23 @@ function Test-PathContainsReparsePoint {
         [string]$RelativePath
     )
 
-    $current = Get-Item -LiteralPath $Root -Force -ErrorAction Stop
+    $combinedPath = if ($RelativePath) {
+        Join-Path -Path $Root -ChildPath $RelativePath
+    } else {
+        $Root
+    }
+    $fullPath = [System.IO.Path]::GetFullPath($combinedPath)
+    $pathRoot = [System.IO.Path]::GetPathRoot($fullPath)
+    if (-not $pathRoot) {
+        throw 'path must have a local drive root'
+    }
+
+    $current = Get-Item -LiteralPath $pathRoot -Force -ErrorAction Stop
     if (($current.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
         return $true
     }
-    foreach ($component in @($RelativePath.Split([char[]]@('\', '/'), [System.StringSplitOptions]::RemoveEmptyEntries))) {
+    $relativeFullPath = $fullPath.Substring($pathRoot.Length)
+    foreach ($component in @($relativeFullPath.Split([char[]]@('\', '/'), [System.StringSplitOptions]::RemoveEmptyEntries))) {
         $current = Get-Item -LiteralPath (Join-Path -Path $current.FullName -ChildPath $component) -Force -ErrorAction Stop
         if (($current.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
             return $true

--- a/guest_server/scripts/apps-query.ps1
+++ b/guest_server/scripts/apps-query.ps1
@@ -1,0 +1,84 @@
+#Requires -Version 5.1
+#Requires -RunAsAdministrator
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PathPrefix,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PathSuffix,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Fields,
+
+    [ValidateRange(1, 128)]
+    [int]$Limit = 128
+)
+
+$ErrorActionPreference = 'Stop'
+$root = $PathPrefix.TrimEnd('\', '/')
+$relativePath = $PathSuffix.TrimStart('\', '/')
+$selectedFields = @($Fields.Split(',') | ForEach-Object { $_.Trim() })
+$apps = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+function Test-PathContainsReparsePoint {
+    param(
+        [string]$Root,
+        [string]$RelativePath
+    )
+
+    $current = Get-Item -LiteralPath $Root -Force -ErrorAction Stop
+    if (($current.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        return $true
+    }
+    foreach ($component in @($RelativePath.Split([char[]]@('\', '/'), [System.StringSplitOptions]::RemoveEmptyEntries))) {
+        $current = Get-Item -LiteralPath (Join-Path -Path $current.FullName -ChildPath $component) -Force -ErrorAction Stop
+        if (($current.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+            return $true
+        }
+    }
+    return $false
+}
+
+if (Test-Path -LiteralPath $root -PathType Container) {
+    if (Test-PathContainsReparsePoint -Root $root -RelativePath '') {
+        throw 'pathPrefix must not be a reparse point'
+    }
+    $directories = @(Get-ChildItem -LiteralPath $root -Directory -ErrorAction Stop | Sort-Object -Property Name)
+    foreach ($directory in $directories) {
+        if ($apps.Count -ge $Limit) {
+            break
+        }
+
+        $candidate = Join-Path -Path $directory.FullName -ChildPath $relativePath
+        if (-not (Test-Path -LiteralPath $candidate -PathType Leaf -ErrorAction SilentlyContinue)) {
+            continue
+        }
+        $relativeCandidate = Join-Path -Path $directory.Name -ChildPath $relativePath
+        if (Test-PathContainsReparsePoint -Root $root -RelativePath $relativeCandidate) {
+            continue
+        }
+
+        $resolved = (Resolve-Path -LiteralPath $candidate -ErrorAction Stop).ProviderPath
+        $name = $null
+        try {
+            $name = (Get-Item -LiteralPath $resolved -ErrorAction Stop).VersionInfo.FileDescription
+        } catch { }
+        if (-not $name -or -not $name.Trim()) {
+            $name = [System.IO.Path]::GetFileNameWithoutExtension($resolved)
+        }
+
+        $available = [ordered]@{
+            Name   = $name.Trim()
+            Path   = $resolved
+            Source = 'filesystem'
+        }
+        $projected = [ordered]@{}
+        foreach ($field in $selectedFields) {
+            $projected[$field] = $available[$field]
+        }
+        $apps.Add([PSCustomObject]$projected)
+    }
+}
+
+ConvertTo-Json -InputObject @($apps) -Depth 3 -Compress


### PR DESCRIPTION
## Status

This PR is intentionally **Draft** while the API direction is discussed in #865 and the current head is revalidated on a real Windows Guest. It should not be marked ready until maintainers confirm the preferred API shape and the live validation checklist below is complete.

Closes #865

## Summary

- advertise the versioned `apps-query-v1` capability and bearer authentication mode from `/health`
- add a backwards-compatible projected `/apps` query that checks `pathPrefix/<immediate child>/<pathSuffix>` without loading icons
- bound projected path inputs, fields, result count, serialized bytes, and PowerShell execution time
- reject malformed, repeated, unknown, UNC, traversal, wildcard, control-character, invalid-character, and reparse-point inputs
- retain the existing query-less `/apps` execution and response behavior for current WinBoat clients
- package all required runtime scripts through an explicit SYSTEM-service allowlist and fail the build if a referenced script is absent

## Motivation

A consumer that needs a few known executables currently pays for the complete application inventory and every base64 icon. Only four matching Studio Pro executables were needed in the measured use case.

The proposed contract is:

```text
GET /apps?includeIcons=false&pathPrefix=C%3A%5CProgram%20Files%5CMendix%5C&pathSuffix=%5Cmodeler%5Cstudiopro.exe&fields=Name%2CPath%2CSource&limit=128
```

Clients discover support through `/health`; old Guests that return only `{"status":"ok"}` remain compatible. The API alternatives and product fit are being discussed in #865 before final review.

## Prototype same-VM benchmark

The initial implementation was measured on a Windows VM on August 26, 2026, with ten samples per route and nearest-rank percentiles:

| Route | p50 | p95 | Mean | Payload |
| --- | ---: | ---: | ---: | ---: |
| existing full `/apps` | 3,385.625ms | 4,176.510ms | 3,466.574ms | 231,882 bytes |
| prototype `apps-query-v1` | 655.624ms | 765.962ms | 670.683ms | 454 bytes |

That prototype reduced p50 by 80.64%, p95 by 81.66%, and payload size by 99.804%. No sample was discarded. The current head contains additional packaging, path-safety, output-bounding, compatibility, and handler-test changes; its Windows measurements must be refreshed before this PR is marked ready.

## Safety and compatibility

- The existing bearer middleware continues to protect `/apps`.
- Parameter values are single-quoted and only fixed, validated parameter names enter the PowerShell command.
- Projected execution is capped at 10 seconds, 128 records, and 256 KiB of captured stdout.
- Query-less legacy `/apps` retains its pre-PR execution and response behavior.
- Unknown, repeated, malformed, oversized, or unsafe projected inputs fail with 400.
- Projection always serializes a JSON array, including zero or one result.
- Reparse points are checked from the volume root through every resolved executable component.
- `guest_server/API.md` documents capability negotiation and downgrade behavior.

## Validation completed on the current head

- `go test -count=1 ./...`
- `go vet ./...`
- `GOOS=windows GOARCH=amd64 go build ./...`
- `GOOS=windows GOARCH=amd64 go vet ./...`
- `GOOS=windows GOARCH=amd64 go test -count=1 ./cmd/server`
- `bash -n build-guest-server.sh`
- complete `bash build-guest-server.sh`, including runtime-script packaging guard
- generated Guest update ZIP inspected for `apps-query.ps1`, `apps.ps1`, `get-icon.ps1`, `time-sync.bat`, and the Guest executable
- `bun run build:linux-gs` (renderer/main production build and AppImage, DEB, RPM, and TAR packaging)
- `git diff --check`

## Validation required before Ready for review

- run the current head through the Guest updater on a real Windows VM
- verify projected zero/one/multiple response shapes and HTTP 400/401/500/504 behavior
- verify NTFS junction/symlink/reparse-point rejection on Windows
- repeat the ten-sample legacy/projected benchmark on the current head
- confirm the installed Guest advertises `apps-query-v1` only when its backing script is present

## AI assistance disclosure

AI-assisted development was used for implementation review, edge-case analysis, test generation, and documentation review. Every change was manually reviewed, and the exact completed and pending validation steps are listed above.

## Consumer

The initial consumer integration is documented at GG-O-BP/mendimaru#55. It negotiates the capability and retains a legacy fallback for older Guests.
