### PR TITLE
Use zip -X for winboat_guest_server

### DIFF
--- a/build-guest-server.sh
+++ b/build-guest-server.sh
@@ -62,6 +62,6 @@ cp install.bat nssm.exe RDPApps.reg "$DIST/oem/"
 # The update payload is what lands in C:\Program Files\WinBoat\server —
 # the Guest Server Updater extracts it back into server\ on update. Built from an
 # explicit directory so no source files or stale archives leak into the package.
-( cd "$DIST/oem/server" && zip -r -q "../../update/winboat_guest_server.zip" . )
+( cd "$DIST/oem/server" && zip -r -X -q "../../update/winboat_guest_server.zip" . )
 
 echo "Guest binaries built into guest_server/$DIST"


### PR DESCRIPTION
on openSUSE, this is enough to make the whole package build bit-reproducible, because we have a zip patch that makes it normalize mtimes as well.