### PR TITLE
fix: migrate pre-#817 compose files to the fixed host ports

### DIFF
--- a/src/renderer/lib/migrate.ts
+++ b/src/renderer/lib/migrate.ts
@@ -1,7 +1,12 @@
 import { createLogger } from "../utils/log";
 import { WINBOAT_DIR } from "./constants";
+import { hasFixedHostPorts, withFixedHostPorts } from "../utils/composePorts";
+import { WinboatConfig } from "./config";
+import { createContainer } from "./containers/common";
+import { Winboat } from "./winboat";
 
 const path: typeof import("path") = require("path");
+const fs: typeof import("fs") = require("fs");
 const logger = createLogger(path.join(WINBOAT_DIR, "migrations.log"));
 
 type Migration = {
@@ -15,7 +20,40 @@ type Migration = {
  * Migrations run in order on every app start, each gated by its own `isNeeded` check.
  */
 const migrations: Migration[] = [
-    // No migrations for the current release cycle
+    {
+        // Installations created before the switch to fixed host ports bound their
+        // services across ranges (47270-47279, 47280-47289, ...) and the app found
+        // the real port by querying the container at runtime. That lookup is gone,
+        // so the host now talks to fixed ports the old container never published
+        // and the Guest Server API can never come online. Rewrite the block and
+        // redeploy so the container actually publishes what the app connects to.
+        name: "compose-fixed-host-ports",
+        isNeeded: () => {
+            const wbConfig = WinboatConfig.getInstance();
+            const containerMgr = createContainer(wbConfig.config.containerRuntime);
+
+            // Nothing to migrate if this install has no compose file to rewrite
+            if (!fs.existsSync(containerMgr.composeFilePath)) return false;
+
+            const compose = Winboat.readCompose(containerMgr.composeFilePath);
+
+            return !hasFixedHostPorts(compose.services.windows.ports ?? []);
+        },
+        migrate: async () => {
+            const wbConfig = WinboatConfig.getInstance();
+            const containerMgr = createContainer(wbConfig.config.containerRuntime);
+            const compose = Winboat.readCompose(containerMgr.composeFilePath);
+            const existing = compose.services.windows.ports ?? [];
+
+            compose.services.windows.ports = withFixedHostPorts(existing);
+
+            logger.info(`[compose-fixed-host-ports]: Replacing port mappings ${JSON.stringify(existing)}`);
+            logger.info(`[compose-fixed-host-ports]: New port mappings ${JSON.stringify(compose.services.windows.ports)}`);
+
+            // Backs up the old compose and redeploys the container with the new one.
+            await Winboat.getInstance().replaceCompose(compose);
+        },
+    },
 ];
 
 /**

--- a/src/renderer/utils/composePorts.ts
+++ b/src/renderer/utils/composePorts.ts
@@ -1,0 +1,39 @@
+import {
+    COMPOSE_PORT_MAPPINGS,
+    GUEST_API_PORT,
+    GUEST_NOVNC_PORT,
+    GUEST_QMP_PORT,
+    GUEST_RDP_PORT,
+    GUEST_UPDATE_PORT,
+    HOST_API_PORT,
+} from "../lib/constants";
+
+/** Guest ports WinBoat manages itself. Anything else in a compose file is the user's own. */
+const MANAGED_GUEST_PORTS = [
+    GUEST_NOVNC_PORT,
+    GUEST_API_PORT,
+    GUEST_QMP_PORT,
+    GUEST_UPDATE_PORT,
+    GUEST_RDP_PORT,
+].map(String);
+
+/** Pulls the guest-side port out of a compose mapping, e.g. "127.0.0.1:47280-47289:7148/tcp" -> "7148" */
+export function guestPortOf(mapping: string): string {
+    return mapping.split("/")[0].split(":").pop() ?? "";
+}
+
+/** True once the Guest Server API is published on the fixed port the app actually dials. */
+export function hasFixedHostPorts(ports: string[]): boolean {
+    return ports.some(
+        mapping => guestPortOf(mapping) === String(GUEST_API_PORT) && mapping.includes(`:${HOST_API_PORT}:`),
+    );
+}
+
+/**
+ * Swaps WinBoat's own mappings for the fixed ones, leaving any port the user
+ * added themselves untouched.
+ */
+export function withFixedHostPorts(ports: string[]): string[] {
+    const userDefined = ports.filter(mapping => !MANAGED_GUEST_PORTS.includes(guestPortOf(mapping)));
+    return [...COMPOSE_PORT_MAPPINGS, ...userDefined];
+}


### PR DESCRIPTION
#817 replaced dynamic port discovery with fixed host ports. Fresh installs are fine because defaultCompose is built from COMPOSE_PORT_MAPPINGS. Existing installs are not, and nothing rewrites their compose, so the Guest Server API can never come online.

The same commit removed migrateComposePorts_Pre090 and left the migrations list empty. COMPOSE_PORT_MAPPINGS is only referenced when building defaultCompose, and writeCompose is only reached from the installer, so there's no path back.

My install started on 0.9.0 and went through 0.9.2. Docker had the guest API on 47281 while the app dialed 47271. Since the old mappings are ranges, 47271 had been handed to noVNC, so the health check got a 404 from nginx rather than a refused connection.

## What it does

Adds a `compose-fixed-host-ports` migration. If the guest API isn't published on HOST_API_PORT, it rewrites WinBoat's own mappings and redeploys via the existing replaceCompose, which backs up the old file first. Anything mapping a port outside WinBoat's own set is matched by guest port and carried through untouched.

The port maths went into src/renderer/utils/composePorts.ts because migrate.ts imports Winboat, and therefore @electron/remote, which makes it awkward to test outside Electron.

## Testing

Live upgrade against a real 0.9.2 install. Before:

```yaml
ports:
  - 127.0.0.1:47270-47279:8006/tcp
  - 127.0.0.1:47280-47289:7148/tcp
  - 127.0.0.1:47290-47299:7149/tcp
  - 127.0.0.1:47300-47309:3389/tcp
  - 127.0.0.1:47300-47309:3389/udp
```

After, written automatically on next launch:

```yaml
ports:
  - 127.0.0.1:47270:8006
  - 127.0.0.1:47271:7148
  - 127.0.0.1:47274:7150
  - 127.0.0.1:47272:7149
  - 127.0.0.1:47273:3389/tcp
  - 127.0.0.1:47273:3389/udp
```

migrations.log from that run:

    Running migration 'compose-fixed-host-ports'
    [compose-fixed-host-ports]: Replacing port mappings [...ranges...]
    [compose-fixed-host-ports]: New port mappings [...fixed...]

Container redeployed, old compose backed up to backup/, and the Guest API went Offline to Online with no manual step.

Also covered the pure helpers with bun test locally for idempotency, preserving user added ports, and leaving fresh installs alone. Those aren't in the diff since the repo has no test harness yet and #753 is adding one.
