### PR TITLE
fix: show Guest Server update failures instead of reporting success

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -29,7 +29,12 @@
 
         <!-- Updater -->
         <dialog ref="updateDialog">
-            <Icon class="text-indigo-400 size-12" icon="mdi:cloud-upload"></Icon>
+            <Icon
+                v-if="winboat?.guestServerUpdateError.value"
+                class="text-red-400 size-12"
+                icon="clarity:warning-solid"
+            ></Icon>
+            <Icon v-else class="text-indigo-400 size-12" icon="mdi:cloud-upload"></Icon>
             <template v-if="manualUpdateRequired">
                 <h3 class="mt-2">Manual Guest Server Update Required</h3>
                 <div class="max-w-[60vw]">
@@ -37,6 +42,9 @@
                         >WinBoat has encountered an issue while trying to update the Guest Server automatically. Please
                         follow the steps below to manually update it:</strong
                     >
+                    <p v-if="winboat?.guestServerUpdateError.value" class="text-sm text-red-400/90 break-words">
+                        {{ winboat.guestServerUpdateError.value }}
+                    </p>
                     <ol class="mt-2 list-decimal list-inside">
                         <li>
                             Use VNC over at
@@ -71,14 +79,17 @@
                 </div>
             </template>
 
-            <template v-else>
-                <h3 class="mt-2" v-if="winboat?.isUpdatingGuestServer.value">Updating Guest Server</h3>
-                <h3 class="mt-2" v-else>Guest Server update successful!</h3>
-                <p v-if="winboat?.isUpdatingGuestServer.value" class="max-w-[40vw]">
+            <template v-else-if="winboat?.isUpdatingGuestServer.value">
+                <h3 class="mt-2">Updating Guest Server</h3>
+                <p class="max-w-[40vw]">
                     The guest is currently running an outdated version of the WinBoat Guest Server. Please wait while we
                     update it to the current version.
                 </p>
-                <p v-else class="max-w-[40vw]">
+            </template>
+
+            <template v-else>
+                <h3 class="mt-2">Guest Server update successful!</h3>
+                <p class="max-w-[40vw]">
                     The WinBoat Guest Server has been updated successfully! You can now close this dialog and continue
                     using the application.
                 </p>
@@ -219,7 +230,9 @@ onMounted(async () => {
                     clearTimeout(updateTimeout);
                     updateTimeout = null;
                 }
-                manualUpdateRequired.value = false;
+                // A failed update still needs the manual steps. Clearing this on
+                // failure used to replace them with a success message.
+                manualUpdateRequired.value = Boolean(winboat?.guestServerUpdateError.value);
             }
         },
     );

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -229,6 +229,8 @@ export class Winboat {
     // Variables
     isOnline: Ref<boolean> = ref(false);
     isUpdatingGuestServer: Ref<boolean> = ref(false);
+    /** Reason the last Guest Server update failed, or null if it succeeded. */
+    guestServerUpdateError: Ref<string | null> = ref(null);
     containerStatus: Ref<ContainerStatus> = ref(ContainerStatus.EXITED);
     containerActionLoading: Ref<boolean> = ref(false);
     rdpConnected: Ref<boolean> = ref(false);
@@ -308,7 +310,11 @@ export class Winboat {
                 logger.info(`Winboat Guest API went ${this.isOnline.value ? "online" : "offline"}`);
 
                 if (this.isOnline.value) {
-                    await this.checkVersionAndUpdateGuestServer();
+                    try {
+                        await this.checkVersionAndUpdateGuestServer();
+                    } catch {
+                        /* already logged, and surfaced via guestServerUpdateError */
+                    }
                 }
             }
         }, HEALTH_WAIT_MS);
@@ -793,6 +799,7 @@ export class Winboat {
         //    applies it atomically and rolls back if the new server fails to come
         //    up. Auth is the shared token; the raw zip is the request body.
         this.isUpdatingGuestServer.value = true;
+        this.guestServerUpdateError.value = null;
         const zipPath = guestServerUpdateZipPath();
         logger.info(`Sending update payload to the Guest Server Updater: ${zipPath}`);
 
@@ -812,6 +819,7 @@ export class Winboat {
         } catch (e) {
             logger.error("Failed to apply Guest Server update");
             logger.error(e);
+            this.guestServerUpdateError.value = e instanceof Error ? e.message : String(e);
             this.isUpdatingGuestServer.value = false;
             throw e;
         }
@@ -830,6 +838,7 @@ export class Winboat {
             logger.info("Update completed, Winboat Guest Server is online");
         } else {
             logger.error("Guest Server did not report healthy within the timeout after update");
+            this.guestServerUpdateError.value = "The Guest Server did not come back online after the update.";
         }
 
         this.isUpdatingGuestServer.value = false;


### PR DESCRIPTION
A failed Guest Server update displays "Guest Server update successful!". The dialog only has isUpdatingGuestServer to go on, and the failure path clears that flag exactly like the success path, so App.vue falls through to a v-else hardcoded to success. There is no failure branch.

Not theoretical. My guest server sat on 0.9.0-alpha across two app versions and I had no idea, because all 12 failures in my log reported success:

    Current version of WinBoat Guest Server: 0.9.0-alpha
    Failed to send update payload to guest server
    Error: Unauthorized: failed to read auth hash

On main the failure is slower, so the 60s timeout shows Manual Guest Server Update Required first and the success message then replaces it, removing instructions the user was mid-way through reading.

## What this does

Adds guestServerUpdateError, set on both failure paths and cleared when an update starts. The existing manual steps stay up on failure with the error above them, and the icon switches to the warning one. Also wraps the call site, which rethrows into a bare await and became an unhandled rejection.

No wording changes, and it doesn't fix provisioning. It stops the app claiming a success it didn't have.

## Testing

Against a real failing update on main: reports failure, error shown, all 9 steps intact. The instant-failure variant on 0.9.2 isn't reproducible on main, so that path is reasoned from the same flag flip rather than run.
