### PR TITLE
fix: surface why a container action failed, and recover from stale networks

### DIFF
--- a/src/renderer/lib/containers/container.ts
+++ b/src/renderer/lib/containers/container.ts
@@ -41,12 +41,17 @@ export enum ContainerStatus {
 
 // Errors which usually indicate that the container is in a stale/broken state,
 // e.g. because it references a passed-through USB device that is no longer
-// present on the host. In these cases the container can't be started again and
-// needs to be recreated from the compose file
+// present on the host, or a network that has since been pruned. In these cases
+// the container can't be started again and needs to be recreated from the
+// compose file. Patterns must stay specific: Docker reuses its "failed to set up
+// container networking" prefix for port binding failures, which are not stale.
 const STALE_CONTAINER_ERROR_PATTERNS = [
     /cannot stat `[^`]*`:?\s*no such file or directory/i,
+    /error gathering device information while adding custom device/i,
     /oci runtime attempted to invoke a command that was not found/i,
     /no such device or address/i,
+    /network [^\s"']+ not found/i,
+    /unable to find network/i,
 ];
 
 function getErrorText(error: unknown): string {
@@ -69,4 +74,25 @@ function getErrorText(error: unknown): string {
 export function isStaleContainerError(error: unknown): boolean {
     const text = getErrorText(error);
     return STALE_CONTAINER_ERROR_PATTERNS.some(pattern => pattern.test(text));
+}
+
+/**
+ * Condenses a raw container-runtime error into a single line for the UI, by
+ * preferring the daemon's own message over the command wrapper around it.
+ */
+export function summarizeContainerError(error: unknown): string {
+    const lines = getErrorText(error)
+        .split("\n")
+        .map(line => line.trim())
+        .filter(Boolean);
+
+    if (!lines.length) return "Unknown error";
+
+    const daemonLine = lines.find(line => /error response from daemon:/i.test(line));
+    if (daemonLine) {
+        return daemonLine.replace(/^error response from daemon:\s*/i, "");
+    }
+
+    const meaningful = lines.find(line => !/^command failed:/i.test(line));
+    return meaningful ?? lines[0];
 }

--- a/src/renderer/lib/winboat.ts
+++ b/src/renderer/lib/winboat.ts
@@ -12,7 +12,12 @@ import { openLink } from "../utils/openLink";
 import { MultiMonitorMode, WinboatConfig } from "./config";
 import { HOST_QMP_PORT, HOST_RDP_PORT, NOVNC_URL, WINBOAT_API_URL, WINBOAT_DIR, WINBOAT_UPDATE_URL } from "./constants";
 import { ContainerRuntimes, createContainer } from "./containers/common";
-import { ContainerManager, ContainerStatus, isStaleContainerError } from "./containers/container";
+import {
+    ContainerManager,
+    ContainerStatus,
+    isStaleContainerError,
+    summarizeContainerError,
+} from "./containers/container";
 import { ExecFileAsyncError } from "./exec-helper";
 import { QMPManager } from "./qmp";
 
@@ -231,6 +236,8 @@ export class Winboat {
     isUpdatingGuestServer: Ref<boolean> = ref(false);
     containerStatus: Ref<ContainerStatus> = ref(ContainerStatus.EXITED);
     containerActionLoading: Ref<boolean> = ref(false);
+    containerError: Ref<string | null> = ref(null);
+    containerRecovered: Ref<boolean> = ref(false);
     rdpConnected: Ref<boolean> = ref(false);
     metrics: Ref<Metrics> = ref<Metrics>({
         cpu: {
@@ -503,6 +510,12 @@ export class Winboat {
     async startContainer() {
         logger.info("Starting WinBoat container...");
         this.containerActionLoading.value = true;
+        this.containerError.value = null;
+        this.containerRecovered.value = false;
+        // Release the sticky ERROR so the poller can resume; nothing else clears it
+        if (this.containerStatus.value === ContainerStatus.ERROR) {
+            this.containerStatus.value = ContainerStatus.UNKNOWN;
+        }
 
         try {
             // Start the container if it exists and recreate it if starting it runs into an error
@@ -513,9 +526,10 @@ export class Winboat {
                 } catch (e) {
                     if (isStaleContainerError(e)) {
                         logger.warn(
-                            "[startContainer] Container appears to be stale/malfunctioning (e.g. a stale USB passthrough reference). Attempting to recreate it...",
+                            `[startContainer] Container appears to be stale/malfunctioning (${summarizeContainerError(e)}). Attempting to recreate it...`,
                         );
                         await this.recreateContainer();
+                        this.containerRecovered.value = true;
                     } else {
                         throw e;
                     }
@@ -543,6 +557,7 @@ export class Winboat {
             logger.error("There was an error performing the container action.");
             logger.error(e);
             this.containerStatus.value = ContainerStatus.ERROR;
+            this.containerError.value = summarizeContainerError(e);
             throw e;
         } finally {
             this.containerActionLoading.value = false;
@@ -563,15 +578,22 @@ export class Winboat {
     async restartContainer() {
         logger.info("Restarting WinBoat container...");
         this.containerActionLoading.value = true;
+        this.containerError.value = null;
+        this.containerRecovered.value = false;
+        // Release the sticky ERROR so the poller can resume; nothing else clears it
+        if (this.containerStatus.value === ContainerStatus.ERROR) {
+            this.containerStatus.value = ContainerStatus.UNKNOWN;
+        }
         try {
             try {
                 await this.containerMgr!.container("restart");
             } catch (e) {
                 if (isStaleContainerError(e)) {
                     logger.warn(
-                        "[restartContainer] Container appears to be stale/malfunctioning (e.g. a stale USB passthrough reference). Attempting to recreate it...",
+                        `[restartContainer] Container appears to be stale/malfunctioning (${summarizeContainerError(e)}). Attempting to recreate it...`,
                     );
                     await this.recreateContainer();
+                    this.containerRecovered.value = true;
                 } else {
                     throw e;
                 }
@@ -581,6 +603,7 @@ export class Winboat {
             logger.error("There was an error restarting the container.");
             logger.error(e);
             this.containerStatus.value = ContainerStatus.ERROR;
+            this.containerError.value = summarizeContainerError(e);
             throw e;
         } finally {
             this.containerActionLoading.value = false;

--- a/src/renderer/views/Home.vue
+++ b/src/renderer/views/Home.vue
@@ -70,6 +70,27 @@
                             </button>
                         </p>
                     </div>
+
+                    <!-- The actual reason the last container action failed -->
+                    <div
+                        v-if="winboat.containerError.value"
+                        class="flex flex-row items-start gap-1.5 mt-1 text-red-400/90"
+                    >
+                        <Icon class="size-5 flex-none translate-y-0.5" icon="clarity:warning-solid"></Icon>
+                        <p class="!my-0 text-sm max-w-[36rem] break-words">{{ winboat.containerError.value }}</p>
+                    </div>
+
+                    <!-- Shown when a broken container was repaired automatically -->
+                    <div
+                        v-if="winboat.containerRecovered.value"
+                        class="flex flex-row items-start gap-1.5 mt-1 text-amber-400/90"
+                    >
+                        <Icon class="size-5 flex-none translate-y-0.5" icon="mdi:refresh"></Icon>
+                        <p class="!my-0 text-sm max-w-[36rem] break-words">
+                            The container was stale and has been recreated from your compose file. Your Windows disk
+                            was not touched.
+                        </p>
+                    </div>
                 </div>
             </div>
 
@@ -84,7 +105,7 @@
                         winboat.containerStatus.value === ContainerStatus.UNKNOWN ||
                         winboat.containerStatus.value === ContainerStatus.ERROR
                     "
-                    @click="winboat.startContainer()"
+                    @click="runContainerAction(() => winboat.startContainer())"
                 >
                     <Icon class="w-20 h-20 text-green-300" icon="mingcute:play-fill"></Icon>
                 </button>
@@ -100,7 +121,7 @@
                     title="Restart"
                     class="generic-hover"
                     v-if="winboat.containerStatus.value === ContainerStatus.RUNNING"
-                    @click="winboat.restartContainer()"
+                    @click="runContainerAction(() => winboat.restartContainer())"
                 >
                     <Icon class="w-20 h-20 text-orange-300" icon="mingcute:refresh-3-line"></Icon>
                 </button>
@@ -213,6 +234,15 @@ import { capitalizeFirstLetter } from "../utils/capitalize";
 import { openAnchorLink, openContainerLogFile } from "../utils/openLink";
 
 const winboat = Winboat.getInstance();
+
+// Container actions rethrow; the reason is surfaced via winboat.containerError
+async function runContainerAction(action: () => Promise<void>) {
+    try {
+        await action();
+    } catch {
+        /* surfaced via winboat.containerError */
+    }
+}
 const compose = ref<ComposeConfig | null>(null);
 const wallpaper = ref("");
 


### PR DESCRIPTION
Addresses #449, and the symptom in #354.

A failed start tells you almost nothing today. containerStatus goes to ERROR, Home shows "Failed to Start" with a link to the log, and the reason is dropped. The template also called winboat.startContainer() bare, and that rethrows, so the rejection went unhandled.

Three changes.

The reason is kept on the Winboat instance and shown under the container status, so you get the daemon's own message rather than having to open a log file.

isStaleContainerError now recognises two more failures. A missing network, where the container keeps a pruned network's ID baked in and can never start again. And a stale device on Docker: the existing patterns catch crun's wording from #533, while runc says `error gathering device information while adding custom device` and matches none of them, so a Docker user whose passed-through USB device is gone fell straight through. Both already route into recreateContainer, they just weren't matching. Podman network phrasing is matched too.

ERROR was sticky with nothing to clear it. The poller deliberately won't overwrite it, with a comment saying it's kept until the next user action, but no action ever released it, so one failure pinned "Failed to Start" permanently.

## Testing

On a real install, one case at a time.

Missing network: deleted winboat_default, confirmed docker reproduces it, then watched the app detect it, recreate from the compose file, come up, and show the recovery notice.

Port conflict, the case that must not recreate: captured the real string docker produces when host port 47271 is taken, then drove a start with it. Container left untouched, status went to ERROR, and the daemon's "address already in use" text rendered under the status line.

Stale device: captured Docker's wording from a throwaway container with a nonexistent device, and confirmed both it and the crun form reported in #533 now match.

Sticky ERROR: retried from that failed state and confirmed it releases, the message clears, and the poller returns to Running.

